### PR TITLE
Change profile of Sly-Little-Fox

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -86,8 +86,8 @@
     },
     "Sly-Little-Fox":{
       "type":["ideas","localization","community","review"],
-      "link":"https://github.com/Sly-Little-Fox",
-      "picture": "https://github.com/sly-little-fox.png"
+      "link":"hhttps://scratch.mit.edu/users/Sly-Little-Fox/",
+      "picture": "https://cdn2.scratch.mit.edu/get_image/user/78096949_90x90.png?v="
     },
     "michaeIwave":{
       "type":["ideas","bugs"],

--- a/contributors.json
+++ b/contributors.json
@@ -86,7 +86,7 @@
     },
     "Sly-Little-Fox":{
       "type":["ideas","localization","community","review"],
-      "link":"hhttps://scratch.mit.edu/users/Sly-Little-Fox/",
+      "link":"https://scratch.mit.edu/users/Sly-Little-Fox/",
       "picture": "https://cdn2.scratch.mit.edu/get_image/user/78096949_90x90.png?v="
     },
     "michaeIwave":{


### PR DESCRIPTION
Their Github account no longer exists and thus the image that is being fetched in the credits page doesn't exist either. 

Change: Changed the profile picture and profile link to their scratch account as confirmed by: https://discord.com/channels/945340853189247016/1001984750992498691/1002946727659192360