### PR TITLE
Impr: Make credits page cleaner

### DIFF
--- a/style.css
+++ b/style.css
@@ -285,29 +285,30 @@ div.feature p {
   top: -0.5rem;
   margin-left: 60px;
 }
-h3 {
-    text-align: center;
+
+.credit img {
+  width: 5.5rem;
+  height: 5.5rem;
+  border-radius: 1rem;
+  margin-left: 57px;
 }
 
+h3 {
+  text-align: center;
+}
 
 div.feature h2 {
   font-size: 1.1rem;
 }
 
 .beta-colorful-design {
-    display: none;
+  display: none;
 }
 
 .credits {
-    margin-top: 2rem;
+  margin-top: 2rem;
 }
-.credit img {
-  width: 5.5rem;
-  height: 5.5rem;
-  border-radius: 1rem;
-  margin-left: 57px;
 
-}
 
 .new-features > div.feature p {
   margin-top: -0.5rem;

--- a/style.css
+++ b/style.css
@@ -268,15 +268,6 @@ div.credit {
   position: relative;
 }
 
-.credit img {
-    width: 2rem;
-    height: 2rem;
-    border-radius: 1rem;
-    position: absolute;
-    top: 6.5rem;
-    left: 1.5rem;
-}
-
 div.credit {
   width: 14rem;
   height: 14rem;
@@ -292,31 +283,30 @@ div.feature p {
   text-decoration: none;
   position: relative;
   top: -0.5rem;
+  margin-left: 60px;
 }
+h3 {
+    text-align: center;
+}
+
 
 div.feature h2 {
   font-size: 1.1rem;
 }
 
-.colorful-design {
-  background-size: cover;
-  background-position: center center;
-  height: 8rem;
-  width: 100%;
-  border-radius: 0.25rem;
-  border: 0px;
+.beta-colorful-design {
+    display: none;
 }
 
 .credits {
     margin-top: 2rem;
 }
+.credit img {
+  width: 5.5rem;
+  height: 5.5rem;
+  border-radius: 1rem;
+  margin-left: 57px;
 
-.beta-colorful-design {
-  background: linear-gradient(45deg, #00a2ff, #29b0ff);
-  height: 8rem;
-  width: 100%;
-  border-radius: 0.25rem;
-  border: 0px;
 }
 
 .new-features > div.feature p {


### PR DESCRIPTION
Changes the image size of the profiles and changes the positioning of the text to make the credits page look cleaner. Suggested by @palindromos

<img width="1438" alt="Screenshot 2024-01-20 at 11 12 16 AM" src="https://github.com/STForScratch/website4/assets/105017592/182c8124-6007-494f-a326-d9d043937bca">


No need to merge yet, I still need to fix the "website" links not getting positioned correctly. 
